### PR TITLE
Docker ubi build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.so
+*.o
+openssl-build/
+openssl-source/
+package/
+builds/
+logs/
+SA64.env
+SA64client.env
+config.in
+engine/makefile
+gem-samples/engineperf/engineperf
+gem-samples/sautil/sautil
+lunaProvider/makefile

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ engine/makefile
 gem-samples/engineperf/engineperf
 gem-samples/sautil/sautil
 lunaProvider/makefile
+luna.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+##############################################################################
+#
+# This file is part of the "Luna OpenSSL for PQC" project.
+#
+# The " Luna OpenSSL for PQC " project is provided under the MIT license (see the
+# following Web site for further details: https://mit-license.org/ ).
+#
+# Copyright © 2025 Thales Group
+#
+##############################################################################
+#
+# Description:
+#   This Dockerfile is used to build a container image for the "Luna OpenSSL for PQC" project.
+
 FROM registry.access.redhat.com/ubi8/ubi
 
 #USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+#USER root
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN \
+    # Upgrade all current packages
+    dnf -y update --setopt=tsflags=nodocs --setopt=install_weak_deps=0 --refresh && \
+    dnf -y install --setopt=tsflags=nodocs --setopt=install_weak_deps=0 \
+    gcc make perl cmake
+RUN \
+    # Create user and group
+    groupadd -g 501 app && \
+    useradd -u 1000 -g app -G app -s /bin/bash bob
+
+# Switch to bob user: if execution required to be root, then it should be stated manually, at container run time
+USER bob
+WORKDIR /home/bob
+
+ENTRYPOINT []
+CMD ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN \
 RUN \
     # Create user and group
     groupadd -g 501 app && \
-    useradd -u 1000 -g app -G app -s /bin/bash bob
+    useradd -u 1000 -g app -G app -s /bin/bash luna
 
-# Switch to bob user: if execution required to be root, then it should be stated manually, at container run time
-USER bob
-WORKDIR /home/bob
+# Switch to luna user: if execution required to be root, then it should be stated manually, at container run time
+USER luna
+WORKDIR /home/luna/luna-openssl-provider
 
 ENTRYPOINT []
 CMD ["/bin/bash", "-l"]

--- a/container-build.sh
+++ b/container-build.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 
-# This script builds the project inside a Docker image.
-# For users who don't want to spend time on environment setup.
+##############################################################################
+##
+## This file is part of the "Luna OpenSSL for PQC" project.
+##
+## The " Luna OpenSSL for PQC " project is provided under the MIT license (see the
+## following Web site for further details: https://mit-license.org/ ).
+##
+## Copyright © 2025 Thales Group
+##
+###############################################################################
+##
+## Description:
+## This script builds the project inside a Docker image.
+## For users who don't want to spend time on environment setup.
 
 # Global variables
 DOCKER_NAME="lunabuilder"

--- a/container-build.sh
+++ b/container-build.sh
@@ -16,6 +16,15 @@ LIBOQS_VERSION="0.12.0"
 LIBOQS_TAR="$LIBOQS_VERSION.tar.gz"
 LIBOQS_URL="https://github.com/open-quantum-safe/liboqs/archive/refs/tags/$LIBOQS_TAR"
 
+function usage() {
+	echo "Builds the Luna OpenSSL provider, Gem Engine, and sautil inside a Docker container."
+	echo
+	echo "Usage: $0 [--rebuild]"
+	echo "  --rebuild | -r : Quickly rebuild the Luna artifacts without downloading dependencies and rebuilding the Docker image."
+	echo "  --help | -h : Show this help message."
+	echo "  If not specified, the script will build the Docker image, download and build dependencies, and then build the Luna artifacts."
+}
+
 function download_deps() {
 	curl -o $(dirname $0)/openssl-source/$OPENSSL_TAR -L $OPENSSL_URL
 	curl -o $(dirname $0)/openssl-source/liboqs-$LIBOQS_TAR -L $LIBOQS_URL
@@ -37,11 +46,14 @@ function pack_tarball() {
 	tar -czf luna.tar.gz -C $(dirname $0) builds
 }
 
-# parse command line arguments
 case "$1" in
-    "--rebuild")
+    "rebuild" | "--rebuild" | "-r")
         CLEAN_BUILD=0
 	;;
+    "help" | "--help" | "-h")
+        usage
+        exit 1
+        ;;
     *)
         CLEAN_BUILD=1
         ;;

--- a/container-build.sh
+++ b/container-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script builds the project inside a Docker image.
+# For users who don't want to spend time on environment setup.
+
+# Global variables
+DOCKER_NAME="lunabuilder"
+DOCKER_OS="ubi" # Red Hat Universal Base Image
+DOCKER_ARCH="amd64"
+DOCKER_IMG="$DOCKER_NAME.$DOCKER_OS.$DOCKER_ARCH"
+DOCKER_RUNNER="docker run --rm -t -v $(dirname $0):/home/luna/luna-openssl-provider $DOCKER_IMG"
+OPENSSL_VERSION="3.5.0"
+OPENSSL_TAR="openssl-$OPENSSL_VERSION.tar.gz"
+OPENSSL_URL="https://github.com/openssl/openssl/releases/download/openssl-3.5.0/$OPENSSL_TAR"
+LIBOQS_VERSION="0.10.0"
+LIBOQS_TAR="$LIBOQS_VERSION.tar.gz"
+LIBOQS_URL="https://github.com/open-quantum-safe/liboqs/archive/refs/tags/$LIBOQS_TAR"
+
+function download_deps() {
+	curl -o $(dirname $0)/openssl-source/$OPENSSL_TAR -L $OPENSSL_URL
+	curl -o $(dirname $0)/openssl-source/liboqs-$LIBOQS_TAR -L $LIBOQS_URL
+}
+
+function build_image() {
+    docker build -t $DOCKER_IMG .
+}
+
+function build_luna() {
+		$DOCKER_RUNNER ./build.sh SA64client clean all
+		$DOCKER_RUNNER ./build.sh SA64client build depends
+		$DOCKER_RUNNER ./build.sh SA64client build all
+}
+
+download_deps
+build_image
+build_luna

--- a/container-build.sh
+++ b/container-build.sh
@@ -25,17 +25,34 @@ function build_image() {
 	docker build -t $DOCKER_IMG .
 }
 
-function build_luna() {
+function clean() {
 	$DOCKER_RUNNER ./build.sh SA64client clean all
-	$DOCKER_RUNNER ./build.sh SA64client build depends
-	$DOCKER_RUNNER ./build.sh SA64client build all
+}
+
+function build_luna() {
+	$DOCKER_RUNNER ./build.sh SA64client build $1
 }
 
 function pack_tarball() {
 	tar -czf luna.tar.gz -C $(dirname $0) builds
 }
 
-download_deps
-build_image
-build_luna
+# parse command line arguments
+case "$1" in
+    "--rebuild")
+        CLEAN_BUILD=0
+	;;
+    *)
+        CLEAN_BUILD=1
+        ;;
+esac
+
+if [ $CLEAN_BUILD -eq 1 ]; then
+    download_deps
+    build_image
+    clean
+    build_luna depends
+fi
+
+build_luna all
 pack_tarball

--- a/container-build.sh
+++ b/container-build.sh
@@ -9,10 +9,10 @@ DOCKER_OS="ubi" # Red Hat Universal Base Image
 DOCKER_ARCH="amd64"
 DOCKER_IMG="$DOCKER_NAME.$DOCKER_OS.$DOCKER_ARCH"
 DOCKER_RUNNER="docker run --rm -t -v $(dirname $0):/home/luna/luna-openssl-provider $DOCKER_IMG"
-OPENSSL_VERSION="3.5.0"
+OPENSSL_VERSION="3.4.1"
 OPENSSL_TAR="openssl-$OPENSSL_VERSION.tar.gz"
 OPENSSL_URL="https://github.com/openssl/openssl/releases/download/openssl-3.5.0/$OPENSSL_TAR"
-LIBOQS_VERSION="0.10.0"
+LIBOQS_VERSION="0.12.0"
 LIBOQS_TAR="$LIBOQS_VERSION.tar.gz"
 LIBOQS_URL="https://github.com/open-quantum-safe/liboqs/archive/refs/tags/$LIBOQS_TAR"
 

--- a/container-build.sh
+++ b/container-build.sh
@@ -22,15 +22,20 @@ function download_deps() {
 }
 
 function build_image() {
-    docker build -t $DOCKER_IMG .
+	docker build -t $DOCKER_IMG .
 }
 
 function build_luna() {
-		$DOCKER_RUNNER ./build.sh SA64client clean all
-		$DOCKER_RUNNER ./build.sh SA64client build depends
-		$DOCKER_RUNNER ./build.sh SA64client build all
+	$DOCKER_RUNNER ./build.sh SA64client clean all
+	$DOCKER_RUNNER ./build.sh SA64client build depends
+	$DOCKER_RUNNER ./build.sh SA64client build all
+}
+
+function pack_tarball() {
+	tar -czf luna.tar.gz -C $(dirname $0) builds
 }
 
 download_deps
 build_image
 build_luna
+pack_tarball

--- a/docs/README-CONTAINER-BUILD
+++ b/docs/README-CONTAINER-BUILD
@@ -1,0 +1,57 @@
+Copyright (c) 2025 Thales Group. All rights reserved.
+
+# PURPOSE
+
+This document describes how to build the Luna OpenSSL Provider, GEM Engine, and `sautil` utility using the provided Docker-based build environment.
+
+## Overview
+
+The build process is encapsulated in a containerized environment based on Red Hat UBI. This ensures a consistent and reproducible build across different systems.
+
+The following components are built:
+
+- **Luna OpenSSL Provider**
+- **GEM Engine**
+- **sautil** utility
+
+## Prerequisites
+
+Ensure the following tools are installed on your system:
+
+- Docker (or Podman)
+- `curl`
+- Git
+
+## Build Instructions
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone --branch docker_ubi_build https://github.com/ThalesGroup/luna-openssl-provider.git
+   cd luna-openssl-provider
+   ```
+2. **Run the container build script**:
+
+The container-build.sh script builds the Docker image and builds the artifacts inside it
+
+
+   ```bash   
+   ./container-build.sh
+   ```
+This script performs the following steps:
+
+Builds the Docker image using the Dockerfile in the root of the repository.
+Runs the container to compile the Luna Provider, GEM Engine, and sautil.
+Packages the resulting binaries and libraries into a compressed archive: luna.tar.gz.
+Verify the output:
+
+3. After the build completes, the `luna.tar.gz` archive will be created in the root directory. It contains the following artifacts:
+
+   ```
+   builds/linux/rhel/64/3.2/
+   ├── sautil
+   ├── lunaprov.so
+   └── gem.so
+   ```
+
+Copyright (c) 2025 Thales Group. All rights reserved.

--- a/gembuild
+++ b/gembuild
@@ -222,7 +222,9 @@ echo "                              to <prefix>/ssl/lib/engines by default."
 echo
 echo "--openssl-api=<major>         Specify the openssl major version you are expecting"
 echo "                              the source code (and this script) to conform with."
-echo "                              Major versions include 1.0.2 or 1.1.1 or 3.0 ."
+echo "                              Major versions include 1.0.2 or 1.1.1, 3.0 or 3.2 ."
+echo "                              As of now, any version of OpenSSL later than 3.2 "
+echo "                              uses the 3.2 API ."
 echo
 echo "--fips-module=yes|no          Build the FIPS module where applicable."
 echo "                              Applies to openssl major version 1.0.2 or 3.0 ."


### PR DESCRIPTION
# Summary
Containerized build system for the Luna OpenSSL Provider, GEM Engine, and sautil utility based on Red Hat UBI 8.

# Key Changes

## Docker-based Build System

- Introduced a Dockerfile based on UBI 8 for building all components.
- Added container-build.sh script to automate image creation, build execution, and artifact packaging.
- Added --rebuild flag for faster incremental builds without rebuilding the base image.

## Artifact Packaging

Artifacts are now packaged into a luna.tar.gz archive containing:

```
builds/linux/rhel/64/3.2/
├── sautil
├── lunaprov.so
└── gem.so

```

## Documentation

- Added docs/README-CONATINER_BUILD explaining prerequisites, build steps, and output structure.

## Dependency Management

- liboqs 0.12
- OpenSSL 3.4.1 (to maintain compatibility with customer environments)

## Licensing and Cleanup

- Added licensing headers to new files.
- Updated .gitignore to exclude build artifacts and compressed outputs.

## Motivation

This containerized approach simplifies the build process, reduces environment-specific issues, and aligns with modern DevOps practices.

Signed-off-by
Eli Waltuch [eli.waltuch@thalesgroup.com](mailto:eli.waltuch@thalesgroup.com)