### PR TITLE
Remove multiple defs of ossl dispatch end

### DIFF
--- a/lunaProvider/lunaCommon.h
+++ b/lunaProvider/lunaCommon.h
@@ -12,10 +12,6 @@
 #ifndef _LUNACOMMON_H
 #define _LUNACOMMON_H
 
-#ifndef LUNA_OQS
-# define OSSL_DISPATCH_END { 0, NULL }
-#endif
-
 /* openssl headers */
 #define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/core.h>

--- a/lunaProvider/lunaEcGen.c
+++ b/lunaProvider/lunaEcGen.c
@@ -301,6 +301,23 @@ int ec_has(const void *keydata, int selection)
     if ((selection & EC_POSSIBLE_SELECTIONS) == 0)
         return 1; /* the selection is not missing */
 
+    /* For private key selection, check if this is an HSM key.
+     * Reject software/ephemeral keys - let default provider handle them.
+     * This is critical for TLS 1.3 ephemeral ECDH keys.
+     */
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+        const int rc_check = luna_prov_ec_check_private(ec);
+        if (luna_prov_check_is_software(rc_check)) {
+            /* Software/ephemeral key - tell OpenSSL we don't "have" it */
+            return 0;
+        }
+        if (!luna_prov_check_is_hardware(rc_check)) {
+            /* Error - malformed key */
+            return 0;
+        }
+        /* HSM key - continue with normal checks */
+    }
+
     if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
         ok = ok && (EC_KEY_get0_public_key(ec) != NULL);
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)

--- a/lunaProvider/lunaEcdh.c
+++ b/lunaProvider/lunaEcdh.c
@@ -105,6 +105,21 @@ int luna_ecdh_init(void *vpecdhctx, void *vecdh, const OSSL_PARAM params[])
             || vecdh == NULL
             || !EC_KEY_up_ref(vecdh))
         return 0;
+
+    /* Check if this is an HSM key - reject software/ephemeral keys */
+    const int rc_check = luna_prov_ec_check_private(vecdh);
+    if (luna_prov_check_is_software(rc_check)) {
+        /* This is a software/ephemeral key - refuse to handle it.
+         * OpenSSL will fall back to default provider.
+         * This is critical for TLS 1.3 ephemeral ECDH keys.
+         */
+        return 0;
+    }
+    if (!luna_prov_check_is_hardware(rc_check)) {
+        /* Error case - malformed key */
+        return 0;
+    }
+
     EC_KEY_free(pecdhctx->k);
     pecdhctx->k = vecdh;
     pecdhctx->cofactor_mode = -1;

--- a/lunaProvider/lunaEcx.c
+++ b/lunaProvider/lunaEcx.c
@@ -96,6 +96,23 @@ static int ecx_init(void *vecxctx, void *vkey,
         return 0;
     }
 
+    /* Check if this is an HSM key - reject software/ephemeral keys.
+     * This is critical for TLS 1.3 ephemeral X25519/X448 keys.
+     */
+    const int rc_check = luna_prov_ecx_check_private(key);
+    if (luna_prov_check_is_software(rc_check)) {
+        /* Software/ephemeral key - refuse to handle it.
+         * OpenSSL will fall back to default provider.
+         */
+        ossl_ecx_key_free(key);
+        return 0;
+    }
+    if (!luna_prov_check_is_hardware(rc_check)) {
+        /* Error case - malformed key */
+        ossl_ecx_key_free(key);
+        return 0;
+    }
+
     ossl_ecx_key_free(ecxctx->key);
     ecxctx->key = key;
 

--- a/lunaProvider/lunaEcxGen.c
+++ b/lunaProvider/lunaEcxGen.c
@@ -143,6 +143,23 @@ static int ecx_has(const void *keydata, int selection)
 
     LUNA_PRINTF(("ossl_prov_is_running\n"));
     if (ossl_prov_is_running() && key != NULL) {
+        /* For private key selection, check if this is an HSM key.
+         * Reject software/ephemeral keys - let default provider handle them.
+         * This is critical for TLS 1.3 ephemeral X25519/X448 keys.
+         */
+        if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+            const int rc_check = luna_prov_ecx_check_private(key);
+            if (luna_prov_check_is_software(rc_check)) {
+                /* Software/ephemeral key - tell OpenSSL we don't "have" it */
+                return 0;
+            }
+            if (!luna_prov_check_is_hardware(rc_check)) {
+                /* Error - malformed key */
+                return 0;
+            }
+            /* HSM key - continue with normal checks */
+        }
+
         /*
          * ECX keys always have all the parameters they need (i.e. none).
          * Therefore we always return with 1, if asked about parameters.

--- a/lunaProvider/lunaRsaGen.c
+++ b/lunaProvider/lunaRsaGen.c
@@ -208,6 +208,11 @@ static int rsa_export(void *keydata, int selection,
     if (!luna_prov_is_running() || rsa == NULL)
         return 0;
 
+     // REFUSE to export private key - it's in the HSM
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+        return 0;  // Cannot export private key from HSM
+    }
+
     if ((selection & RSA_POSSIBLE_SELECTIONS) == 0)
         return 0;
 
@@ -218,11 +223,9 @@ static int rsa_export(void *keydata, int selection,
     if ((selection & OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS) != 0)
         ok = ok && (ossl_rsa_pss_params_30_is_unrestricted(pss_params)
                     || ossl_rsa_pss_params_30_todata(pss_params, tmpl, NULL));
-    if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
-        int include_private =
-            selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY ? 1 : 0;
-
-        ok = ok && ossl_rsa_todata(rsa, tmpl, NULL, include_private);
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+        // Only export public key components
+        ok = ok && ossl_rsa_todata(rsa, tmpl, NULL, 0);  // 0 = no private
     }
 
     if (!ok


### PR DESCRIPTION
## Remove unneeded, unguarded, and incorrect definition of OSSL_DISPATCH_END :

We already define this macro only when the OpenSSL version is older than 3.2
And only after we check that it isnt already defined

We need to remove this other definition that is dependent on LUNA_OQS being undefined
and does not check for pre-definition

## Reject software/ephemeral keys and block HSM private key export

  The Luna provider should only handle HSM-backed keys. This change ensures
  proper fallback to the default OpenSSL provider for software and ephemeral
  keys, which is critical for TLS 1.3 ephemeral ECDH/X25519/X448 operations.

  Changes:
  - EC/ECX key management now checks if keys are HSM-backed before claiming them
  - ECDH and X25519/X448 key exchange reject non-HSM keys at init time
  - RSA export explicitly refuses to export private keys from HSM
  - All rejections return 0 to trigger OpenSSL fallback to default provider

  This fixes compatibility issues where the provider incorrectly attempted to
  handle ephemeral keys that must be processed in software.